### PR TITLE
Fix unit tests with path for blabbr configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
   "jest": {
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
-      "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js"
+      "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js",
+      "blabbr-config": "<rootDir>/config/blabbr-config.js"
     }
   }
 }

--- a/src/components/comment/__snapshots__/test.jsx.snap
+++ b/src/components/comment/__snapshots__/test.jsx.snap
@@ -1,6 +1,6 @@
 exports[`test Comment renders correctly 1`] = `
 <article
-  className="blabbr-comment">
+  className="blabbr-comment withAvatar">
   <header>
     <h2>
       username

--- a/src/components/onlineIndicator/__snapshots__/test.jsx.snap
+++ b/src/components/onlineIndicator/__snapshots__/test.jsx.snap
@@ -1,29 +1,25 @@
-exports[`test Offline indicator renderes correctly 1`] = `
+exports[`test Online indicator renders correctly when system is offline 1`] = `
 <div
-  className="status-indicator">
-  <span>
-    Connection status: 
-  </span>
-  <span
-    className="offline">
-    <span>
-      Offline
-    </span>
-  </span>
+  className="blabbr-status-indicator offline"
+  data-for="blabbr-indicator-tooltip"
+  data-tip={true}>
+  <wrapper
+    className="__react_component_tooltip place-top type-dark "
+    data-id="tooltip">
+    
+  </wrapper>
 </div>
 `;
 
-exports[`test Online indicator renderes correctly 1`] = `
+exports[`test Online indicator renders correctly when system is online 1`] = `
 <div
-  className="status-indicator">
-  <span>
-    Connection status: 
-  </span>
-  <span
-    className="online">
-    <span>
-      Online
-    </span>
-  </span>
+  className="blabbr-status-indicator online"
+  data-for="blabbr-indicator-tooltip"
+  data-tip={true}>
+  <wrapper
+    className="__react_component_tooltip place-top type-dark "
+    data-id="tooltip">
+    
+  </wrapper>
 </div>
 `;

--- a/src/components/onlineIndicator/test.jsx
+++ b/src/components/onlineIndicator/test.jsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import renderer from 'react-test-renderer'; // eslint-disable-line
-import Offline from './';
+import OnlineIndicator from './';
 
-test('Offline indicator renderes correctly', () => {
+test('Online indicator renders correctly when system is offline', () => {
   const tree = renderer.create(
-    <Offline isOnline={false} />,
+    <OnlineIndicator isOnline={false} />,
   ).toJSON();
   expect(tree).toMatchSnapshot();
 });
 
-test('Online indicator renderes correctly', () => {
+test('Online indicator renders correctly when system is online', () => {
   const tree = renderer.create(
-    <Offline isOnline />,
+    <OnlineIndicator isOnline />,
   ).toJSON();
   expect(tree).toMatchSnapshot();
 });


### PR DESCRIPTION
This PR:
* fixes test configuration for jest to provide path of blabbr-config
* it updates snapshots as markup has significantly changed in last couple of weeks, using `node_modules/.bin/jest --updateSnapshot`
* modifies snapshot for comment component for addition of blabblr-config that wants to show avatar