### PR TITLE
Add trimming to comments and modify button label

### DIFF
--- a/src/components/api/index.js
+++ b/src/components/api/index.js
@@ -83,8 +83,9 @@ export const postComment = ({
   }));
 };
 
-export const updateComment = (commentId, userComment) => {
+export const updateComment = (commentId, userCommentText) => {
   const timestampId = `${new Date().getTime()}`;
+  const userComment = userCommentText && userCommentText.trim();
 
   return db.find({
     selector: {

--- a/src/components/panel/index.jsx
+++ b/src/components/panel/index.jsx
@@ -142,7 +142,7 @@ export default class Panel extends Component {
     e.preventDefault();
     e.stopPropagation();
 
-    this.addComment(userComment);
+    this.addComment(userComment && userComment.trim());
     this.setState({ userComment: '' });
   }
 
@@ -151,6 +151,10 @@ export default class Panel extends Component {
     e.stopPropagation();
 
     this.setState({ commentIdBeingEdited: e.target.id });
+    const commentBeingEdited = this.allComments.find((comment) => {
+      return comment._id === e.target.id;
+    });
+    this.setState({ userCommentBeingUpdated: commentBeingEdited.comment });
     this.userActions.edited[e.target.id] = true;
   }
 

--- a/src/components/submitComment/index.jsx
+++ b/src/components/submitComment/index.jsx
@@ -46,7 +46,7 @@ const SubmitComment = ({
             onClick={onCommentCancel}
             title="Cancel"
           >
-            Remove
+            Cancel
           </button>,
         ]
           :


### PR DESCRIPTION
This PR fixes 3 trivial problems with our comments:
* Modify label of a button appropriately to Cancel
* Trims comments now. This does affect the system a bit. I could circumvent the mandatory comment by inserting a space, and so now we can take care of such scenarios.
* Fixes a bug by keeping state up to date w/ user editing. Steps to reproduce:
  1. Edit a comment. Make no change. Save.
  2. Observe that error talks about blank comment. This is because panel state still has null.